### PR TITLE
socket.socketpair() on Windows

### DIFF
--- a/netconf/server.py
+++ b/netconf/server.py
@@ -17,13 +17,15 @@
 # limitations under the License.
 #
 from __future__ import absolute_import, division, unicode_literals, print_function, nested_scopes
+import sys
 import traceback
 import logging
 import io
 import os
 import select
 import socket
-import backports.socketpair
+if sys.platform == 'win32' and sys.version_info < (3, 5):
+    import backports.socketpair
 import threading
 import paramiko as ssh
 from lxml import etree

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -23,6 +23,7 @@ import io
 import os
 import select
 import socket
+import backports.socketpair
 import threading
 import paramiko as ssh
 from lxml import etree
@@ -523,7 +524,7 @@ class NetconfSSHServer (object):
             protosocket.listen(100)
 
             # Create a socket to cause closure.
-            self.close_wsocket, self.close_rsocket = socket.socketpair(socket.AF_UNIX)
+            self.close_wsocket, self.close_rsocket = socket.socketpair()
 
             self.lock = threading.Lock()
             self.session_id = 0

--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 import os
 from setuptools import setup
 
 required = [
-    "backports.socketpair>=3.5.0",
     "lxml>=3.1.0",
     "paramiko>=1.10.1",
     "sshutil>=0.9.0",
 ]
+if sys.platform == 'win32' and sys.version_info < (3, 5):
+    required.append("backports.socketpair>=3.5.0.2")
 
 
 def read(fname):

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ import os
 from setuptools import setup
 
 required = [
+    "backports.socketpair>=3.5.0",
     "lxml>=3.1.0",
     "paramiko>=1.10.1",
     "sshutil>=0.9.0",


### PR DESCRIPTION
Hi Christian,

Thanks for this project! I am using it for my new [modeled.netconf](https://github.com/userzimmermann/python-modeled.netconf) framework. Unfortunately it didn't work under Windows, because Windows Python < 3.5 has no `socket.socketpair()` function. But there is a [backports.socketpair](https://github.com/mhils/backports.socketpair) project patching this. I added it as import and dependency and removed the `AF_UNIX` argument from the `socketpair()` call, as this is also not availabe under Windows, but default under UNIX systems.