### PR TITLE
Add support for operations for non-default namespaces

### DIFF
--- a/netconf/server.py
+++ b/netconf/server.py
@@ -230,6 +230,7 @@ class NetconfServerSession (base.NetconfSession):
     def _rpc_not_implemented (self, unused_session, rpc, *unused_params):
         if self.debug:
             msg_id = int(rpc.get('message-id'))
+            logger.debug("%s: Not Impl msg-id: %s", str(self), str(msg_id))
             logger.debug("%s: Not Impl msg-id: %s, rpc: %s", str(self), str(msg_id), rpc.iterchildren().next().tag)
         raise ncerror.RPCSvrErrNotImpl(rpc)
 

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -325,9 +325,7 @@ class NetconfServerSession (base.NetconfSession):
                     # Handle any namespaces or prefixes in the tag, other than
                     # "nc" which was removed above. Of course, this does not handle
                     # namespace collisions, but that seems reasonable for now.
-                    logger.debug("Original rpcname: %s", rpcname)
                     rpcname = rpcname.rpartition("}")[-1]
-                    logger.debug("Updated rpcname: %s", rpcname)
                     method_name = "rpc_" + rpcname.replace('-', '_')
                     method = getattr(self.methods, method_name, self._rpc_not_implemented)
                     # logger.debug("%s: Calling method: %s", str(self), str(methodname))

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -325,7 +325,9 @@ class NetconfServerSession (base.NetconfSession):
                     # Handle any namespaces or prefixes in the tag, other than
                     # "nc" which was removed above. Of course, this does not handle
                     # namespace collisions, but that seems reasonable for now.
+                    logger.debug("Original rpcname: %s", rpcname)
                     rpcname = rpcname.rpartition("}")[-1]
+                    logger.debug("Updated rpcname: %s", rpcname)
                     method_name = "rpc_" + rpcname.replace('-', '_')
                     method = getattr(self.methods, method_name, self._rpc_not_implemented)
                     # logger.debug("%s: Calling method: %s", str(self), str(methodname))

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -230,7 +230,7 @@ class NetconfServerSession (base.NetconfSession):
     def _rpc_not_implemented (self, unused_session, rpc, *unused_params):
         if self.debug:
             msg_id = int(rpc.get('message-id'))
-            logger.debug("%s: Not Impl msg-id: %s", str(self), str(msg_id))
+            logger.debug("%s: Not Impl msg-id: %s, rpc: %s", str(self), str(msg_id), rpc.iterchildren().next().tag)
         raise ncerror.RPCSvrErrNotImpl(rpc)
 
     def _handle_message (self, msg):

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -231,7 +231,6 @@ class NetconfServerSession (base.NetconfSession):
         if self.debug:
             msg_id = int(rpc.get('message-id'))
             logger.debug("%s: Not Impl msg-id: %s", str(self), str(msg_id))
-            logger.debug("%s: Not Impl msg-id: %s, rpc: %s", str(self), str(msg_id), rpc.iterchildren().next().tag)
         raise ncerror.RPCSvrErrNotImpl(rpc)
 
     def _handle_message (self, msg):

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -322,6 +322,10 @@ class NetconfServerSession (base.NetconfSession):
                 #------------------
 
                 try:
+                    # Handle any namespaces or prefixes in the tag, other than
+                    # "nc" which was removed above. Of course, this does not handle
+                    # namespace collisions, but that seems reasonable for now.
+                    rpcname = rpcname.rpartition("}")[-1]
                     method_name = "rpc_" + rpcname.replace('-', '_')
                     method = getattr(self.methods, method_name, self._rpc_not_implemented)
                     # logger.debug("%s: Calling method: %s", str(self), str(methodname))

--- a/tests/test_netconf_svr.py
+++ b/tests/test_netconf_svr.py
@@ -88,6 +88,7 @@ def test_not_supported ():
     try:
         rval = session.send_rpc(query)
     except RPCError as error:
+        logger.info("Error tag {}".format(error.get_error_tag()))
         assert error.get_error_tag() == "operation-not-supported"
     else:
         logger.error("Unexpected success: {}", rval)

--- a/tests/test_netconf_svr.py
+++ b/tests/test_netconf_svr.py
@@ -44,6 +44,9 @@ class NetconfMethods (server.NetconfMethods):
     def rpc_get_config (self, unused_session, rpc, *unused_params):
         return etree.Element("ok")
 
+    def rpc_namespaced (self, unused_session, rpc, *unused_params):
+        return etree.Element("ok")
+
 
 def setup_module (unused_module):
     if setup_module.init:
@@ -89,6 +92,19 @@ def test_not_supported ():
     else:
         logger.error("Unexpected success: {}", rval)
         assert False
+
+
+def test_namespaced_rpc ():
+    """TEST: Checked that namespaced RPCs work."""
+    session = client.NetconfSSHSession("127.0.0.1", port=ncserver.port)
+    assert session
+
+    query = '<namespaced xmlns="some:namespace:1.0"></namespaced>'
+    rval = session.send_rpc(query)
+    rval = session.send_rpc(query)
+    assert rval
+    # logger.debug("Get: {}", rval)
+    session.close()
 
 
 def test_malformed ():

--- a/tests/test_netconf_svr.py
+++ b/tests/test_netconf_svr.py
@@ -88,7 +88,6 @@ def test_not_supported ():
     try:
         rval = session.send_rpc(query)
     except RPCError as error:
-        logger.info("Error tag {}".format(error.get_error_tag()))
         assert error.get_error_tag() == "operation-not-supported"
     else:
         logger.error("Unexpected success: {}", rval)


### PR DESCRIPTION
NETCONF notifications as per RFC 5277 use a non-default XML namespace, and the current logic does not handle mapping the incoming calls to Python attributes. The logic in this patch is very simple minded, and would not cope with, for example, two operations in different namespaces that had the same name but the complexity that would require seems far above what is warranted.

Nevertheless, I hope this is considered useful and worth merging into master.
