### PR TITLE
Implement subtree to xpath -filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage.xml
 dist/
 junit-*
 pylint.log
+venv/

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -302,7 +302,7 @@ class NetconfServerSession(base.NetconfSession):
         # Any error with XML encoding here is going to cause a session close
         # Technically we should be able to return malformed message I think.
         try:
-            tree = etree.parse(io.BytesIO(msg.encode('utf-8')))
+            tree = etree.parse(io.BytesIO(msg.lstrip().encode('utf-8')))
             if not tree:
                 raise ncerror.SessionError(msg, "Invalid XML from client.")
         except etree.XMLSyntaxError:

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -20,7 +20,7 @@
 from __future__ import absolute_import, division, unicode_literals, print_function, nested_scopes
 import getpass
 import logging
-from netconf import NSMAP, qmap
+from netconf import NSMAP, qmap, nsmap_add
 import netconf.util as ncutil
 import netconf.error as ncerror
 import netconf.server as ncserver
@@ -31,6 +31,7 @@ NC_PORT = None
 NC_DEBUG = True
 
 mock_module = "urn:mock:module"
+nsmap_add('xmlns', 'http://tail-f.com/ns/ncs')
 
 
 class MockMethods(object):

--- a/tests/test_netconf.py
+++ b/tests/test_netconf.py
@@ -32,17 +32,7 @@ def setup_module(unused_module):
     NC_PORT = init_mock_server()
 
 
-def test_query():
-    query = """
-    <get>
-    <filter type="subtree">
-    <devices xmlns="http://tail-f.com/ns/ncs">
-    <global-settings/>
-    </devices>
-    </filter>
-    </get>
-    """
-
+def test_xpath_query():
     query = """
     <get>
     <filter type="xpath" select="/devices/global-settings"/>
@@ -53,7 +43,23 @@ def test_query():
     session.send_rpc(query)
 
 
-def test_bad_query():
+def test_subtree_query():
+    query = """
+        <get>
+        <filter type="subtree">
+        <devices xmlns="http://tail-f.com/ns/ncs">
+        <global-settings/>
+        </devices>
+        </filter>
+        </get>
+        """
+
+    logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
+    session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
+    session.send_rpc(query)
+
+
+def stest_bad_query():
     session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
     try:
         unused, unused, output = session.send_rpc("<get><unknown/></get>")

--- a/tests/test_netconf.py
+++ b/tests/test_netconf.py
@@ -59,7 +59,7 @@ def test_subtree_query():
     session.send_rpc(query)
 
 
-def stest_bad_query():
+def test_bad_query():
     session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
     try:
         unused, unused, output = session.send_rpc("<get><unknown/></get>")


### PR DESCRIPTION
**NOTE:** This drops support for python 2 due to subtree to xpath -implementation. Python2 is anyway EOL since January 1st 2020, so maybe it should be dropped anyway and create new release with only python3 support? If python 2 -support is needed, I can modify the code to support both.

Summary:
- Implement subtree to xpath -functionality
- Strip leading newline from raw -message. For example [go-netconf](https://github.com/Juniper/go-netconf/blob/ff8000de8090dd7ac6ac485058f5d9bf57579c75/netconf/transport.go#L50) add newline after the  message separator.