### PR TITLE
Subtree filters/no default namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage.xml
 dist/
 junit-*
 pylint.log
+venv/

--- a/doc/source/usage-cli.rst
+++ b/doc/source/usage-cli.rst
@@ -14,10 +14,10 @@ To get the capabilities of a server:
 .. code-block:: sh
 
   $ netconf-client … --hello
-  urn:ietf:params:netconf:capability:xpath:1.0
-  urn:ietf:params:xml:ns:yang:ietf-system
   urn:ietf:params:netconf:base:1.1
   urn:ietf:params:netconf:base:1.0
+  urn:ietf:params:xml:ns:yang:ietf-system
+  urn:ietf:params:netconf:capability:xpath:1.0
 
 .. _cli-auth:
 
@@ -66,7 +66,7 @@ SSH Authentication
 Get Config
 ==========
 
-To request config.
+To request config (see :ref:`cli-auth` for authentication).
 
 .. code-block:: sh
 
@@ -84,14 +84,15 @@ To request config filtered by an xpath expression.
 
 .. code-block:: sh
 
-  $ netconf-client … --get-config="/system/clock"
-  <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  $ netconf-client … --get-config="/sys:system/sys:clock"
+                     --namespaces="sys=urn:ietf:params:xml:ns:yang:ietf-system"
+  <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
     <sys:system xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">
       <sys:clock>
         <sys:timezone-utc-offset>180</sys:timezone-utc-offset>
       </sys:clock>
     </sys:system>
-  </data>
+  </nc:data>
 
 Get State
 =========
@@ -101,32 +102,54 @@ To request operational state (see :ref:`cli-auth` for authentication)
 .. code-block:: sh
 
   $ netconf-client … --get
-  <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-    <sys:system-state xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">
-      <sys:system>
-        <sys:os-name>Linux</sys:os-name>
-        <sys:os-release>4.15.3-2-ARCH</sys:os-release>
-        <sys:os-version>#1 SMP PREEMPT Thu Feb 15 00:13:49 UTC 2018</sys:os-version>
-        <sys:machine>x86_64</sys:machine>
-      </sys:system>
+  <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <sys:system xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">
+      <sys:hostname>tops</sys:hostname>
       <sys:clock>
-        <sys:current-datetime>2018-02-24T12:57:18.537626</sys:current-datetime>
-        <sys:boot-datetime>2018-02-23T09:12:22.838012</sys:boot-datetime>
+        <sys:timezone-utc-offset>180</sys:timezone-utc-offset>
+      </sys:clock>
+    </sys:system>
+    <sys:system-state xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">
+      <sys:platform>
+        <sys:os-name>Linux</sys:os-name>
+        <sys:os-release>5.4.14-arch1-1</sys:os-release>
+        <sys:os-version>#1 SMP PREEMPT Thu, 23 Jan 2020 10:07:05 +0000</sys:os-version>
+        <sys:machine>x86_64</sys:machine>
+      </sys:platform>
+      <sys:clock>
+        <sys:current-datetime>2020-02-11T18:20:14.516992</sys:current-datetime>
+        <sys:boot-datetime>2020-02-10T06:31:26.787100</sys:boot-datetime>
       </sys:clock>
     </sys:system-state>
-  </data>
+  </nc:data>
 
+To request state filtered by a sub-tree XML filter
+
+.. code-block:: sh
+
+  $ netconf-client --port=8300 -u admin -p admin --get '<system-state><platform/></system-state>'
+  <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <sys:system-state xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">
+      <sys:platform>
+        <sys:os-name>Linux</sys:os-name>
+        <sys:os-release>5.4.14-arch1-1</sys:os-release>
+        <sys:os-version>#1 SMP PREEMPT Thu, 23 Jan 2020 10:07:05 +0000</sys:os-version>
+        <sys:machine>x86_64</sys:machine>
+      </sys:platform>
+    </sys:system-state>
+  </nc:data>
 
 To request state filtered by an xpath expression.
 
 .. code-block:: sh
 
-  $ netconf-client … --get="/system-system/clock"
-  <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  $ netconf-client … --get="/sys:system-state/sys:clock" \
+                     --namespaces="sys=urn:ietf:params:xml:ns:yang:ietf-system"
+  <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
     <sys:system-state xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">
       <sys:clock>
-        <sys:current-datetime>2018-02-24T12:57:18.537626</sys:current-datetime>
-        <sys:boot-datetime>2018-02-23T09:12:22.838012</sys:boot-datetime>
+        <sys:current-datetime>2020-02-11T18:27:16.336916</sys:current-datetime>
+        <sys:boot-datetime>2020-02-10T06:31:26.787025</sys:boot-datetime>
       </sys:clock>
     </sys:system-state>
-  </data>
+  </nc:data>

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -302,7 +302,7 @@ class NetconfServerSession(base.NetconfSession):
         # Any error with XML encoding here is going to cause a session close
         # Technically we should be able to return malformed message I think.
         try:
-            tree = etree.parse(io.BytesIO(msg.encode('utf-8')))
+            tree = etree.parse(io.BytesIO(msg.lstrip().encode('utf-8')))
             if not tree:
                 raise ncerror.SessionError(msg, "Invalid XML from client.")
         except etree.XMLSyntaxError:

--- a/netconf/server.py
+++ b/netconf/server.py
@@ -50,7 +50,6 @@ class SSHAuthorizedKeysController(ssh.ServerInterface):
 
     :param users: A list of usernames whose authorized keys will allow access.
     """
-
     def __init__(self, users=None):
         self.event = threading.Event()
         self.users = users
@@ -177,7 +176,6 @@ class SSHUserPassController(ssh.ServerInterface):
     :param username: The username to allow.
     :param password: The password to allow.
     """
-
     def __init__(self, username=None, password=None):
         self.username = username
         self.password = password
@@ -283,7 +281,7 @@ class NetconfServerSession(base.NetconfSession):
 
     def _rpc_not_implemented(self, unused_session, rpc, *unused_params):
         if self.debug:
-            msg_id = rpc.get('message-id')
+            msg_id = rpc.get(qmap("nc") + 'message-id')
             logger.debug("%s: Not Impl msg-id: %s", str(self), msg_id)
         raise ncerror.OperationNotSupportedProtoError(rpc)
 
@@ -315,7 +313,7 @@ class NetconfServerSession(base.NetconfSession):
 
         for rpc in rpcs:
             try:
-                msg_id = rpc.get('message-id')
+                msg_id = rpc.get(qmap("nc") + 'message-id')
                 if self.debug:
                     logger.debug("%s: Received rpc message-id: %s", str(self), msg_id)
             except (TypeError, ValueError):
@@ -478,7 +476,6 @@ class NetconfMethods(object):
     inherit). Create a class that implements the rpc_* methods you handle and pass
     that to `NetconfSSHServer` init.
     """
-
     def nc_append_capabilities(self, capabilities):  # pylint: disable=W0613
         """This method should append any capabilities it supports to capabilities
 
@@ -630,7 +627,6 @@ class NetconfSSHServer(sshutil.server.SSHServer):
     :param host_key: The file containing the host key.
     :param debug: True to enable debug logging.
     """
-
     def __init__(self, server_ctl=None, server_methods=None, port=830, host_key=None, debug=False):
         self.server_methods = server_methods if server_methods is not None else NetconfMethods()
         self.session_id = 1
@@ -639,12 +635,11 @@ class NetconfSSHServer(sshutil.server.SSHServer):
             "running": 0,
             "candidate": 0,
         }
-        super(NetconfSSHServer, self).__init__(
-            server_ctl,
-            server_session_class=NetconfServerSession,
-            port=port,
-            host_key=host_key,
-            debug=debug)
+        super(NetconfSSHServer, self).__init__(server_ctl,
+                                               server_session_class=NetconfServerSession,
+                                               port=port,
+                                               host_key=host_key,
+                                               debug=debug)
 
     def __del__(self):
         logger.error("Deleting %s", str(self))

--- a/netconf/util.py
+++ b/netconf/util.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import copy
 import logging
 from lxml import etree
-from netconf import NSMAP
+from netconf import NSMAP, qmap
 from netconf import error
 
 # Tries to somewhat implement RFC6241 filtering
@@ -28,6 +28,13 @@ logger = logging.getLogger(__name__)
 
 
 def qname(tag):
+    """Return a qualified tag name (i.e. {namespace}localtag)
+
+    Handles prefix notation by looking up in global dictionary.
+
+    :param tag: A possibly prefixed tag.
+    :returns: Fully qualified tag name (`lxml.etree.QName`).
+    """
     try:
         return etree.QName(tag)
     except ValueError:
@@ -36,12 +43,33 @@ def qname(tag):
 
 
 def elm(tag, attrib=None, **extra):
+    """Create an `lxml.etree.Element` using `qname` to obtain the tag.
+
+    This is a replacement for calling `lxml.etree.Element` directly that
+    supports prefixed tags.
+
+    :param tag: A possibly prefixed tag.
+    :param attrib: Attributes for the element.
+    :param **extra: extra parameters see `lxml.etree.Element`.
+    :returns: `lxml.etree.Element`.
+    """
     if attrib is None:
         attrib = dict()
     return etree.Element(qname(tag), attrib, **extra)
 
 
 def leaf_elm(tag, value, attrib=None, **extra):
+    """Create an `lxml.etree.Element` leaf node using `qname` to obtain the tag.
+
+    This is a replacement for calling `lxml.etree.Element` directly that supports
+    prefixed tags.
+
+    :param tag: A possibly prefixed tag.
+    :param value: Value for text of element.
+    :param attrib: Attributes for the element.
+    :param **extra: extra parameters see `lxml.etree.Element`.
+    :returns: `lxml.etree.Element`.
+    """
     e = elm(tag, attrib, **extra)
     e.text = str(value)
     return e
@@ -52,6 +80,17 @@ leaf = leaf_elm
 
 
 def subelm(pelm, tag, attrib=None, **extra):
+    """Create an child `lxml.etree.Element` using `qname` to obtain the tag.
+
+    This is a replacement for calling `lxml.etree.SubElement` directly that
+    supports prefixed tags.
+
+    :param pelm: The parent element.
+    :param tag: A possibly prefixed tag.
+    :param attrib: Attributes for the element.
+    :param **extra: extra parameters see `lxml.etree.SubElement`.
+    :returns: `lxml.etree.Element`.
+    """
     if attrib is None:
         attrib = dict()
     return etree.SubElement(pelm, qname(tag), attrib, **extra)
@@ -150,6 +189,93 @@ def xpath_filter_result(data, xpath):
     return data
 
 
+def _get_xpath_tag(nsmap, ns, child):
+    del ns
+    ctag = qname(child.tag)
+    ns = _ns2prefix(nsmap, ctag.namespace)
+    if ns == "*":
+        return "*[local-name()='{}']".format(ctag.localname), ns
+    else:
+        return "{}:{}".format(ns, ctag.localname), ns
+
+
+def _get_xpath_tag_if_inheritance_worked(nsmap, ns, child):
+    ctag = qname(child.tag)
+    if ((ns != "*" and ctag.namespace == nsmap[ns]) or (ns == "*" and not ctag.namespace)):
+        tag = "{tag}".format(tag=ctag.localname)
+    else:
+        ns = _ns2prefix(nsmap, ctag.namespace)
+        tag = "{ns}:{tag}".format(ns=ns, tag=ctag.localname)
+    return tag, ns
+
+
+def _linearize(el, ns, path):
+
+    mpaths = []
+    select_count = 0
+
+    # Get match criteria
+    for child in el:
+        if len(child) > 0:
+            # This should be a user friendly error
+            # assert not child.text
+            select_count += 1
+        elif child.text and child.text.strip():
+            tag, _ = _get_xpath_tag(NSMAP, ns, child)
+            ctext = child.text.strip().replace("'", r"\'")
+            mpaths.append("{}='{}'".format(tag, ctext))
+        else:
+            select_count += 1
+
+    if mpaths:
+        path += "[" + " or ".join(mpaths) + "]"
+        if not select_count:
+            # If we only have match nodes then return the contained that match
+            yield path
+            return
+
+    for child in el:
+        tag, newns = _get_xpath_tag(NSMAP, ns, child)
+        if len(child) > 0:
+            text = '{path}/{tag}'.format(path=path, tag=tag)
+            for x in _linearize(child, newns, text):
+                yield x
+        else:
+            text = '/{tag}'.format(tag=tag)
+            yield path + text
+
+
+def _ns2prefix(nsmap, namespace):
+    if not namespace:
+        return "*"
+
+    for prefix, ns in nsmap.items():
+        if namespace is None:
+            return prefix
+        if ns == namespace:
+            return prefix
+    # This is an error
+    assert False
+
+
+def filter_to_xpath(felm):
+    """Convert a filter sub-tree to an xpath expression.
+
+    :param felm: A subtree-filter XML sub-tree.
+    :returns str: An xpath expression equivalent to the sub-tree.
+    """
+    root = felm[0]
+    rtag = qname(root.tag)
+    ns = _ns2prefix(root.nsmap, rtag.namespace)
+    xpaths = []
+    root_xpath = _get_xpath_tag(NSMAP, None, root)[0]
+    for path in _linearize(root, ns, "/{}".format(root_xpath)):
+        xpaths.append(path)
+
+    result = ' | '.join(xpaths)
+    return result
+
+
 def filter_results(rpc, data, filter_or_none, debug=False):
     """Check for a user filter and prune the result data accordingly.
 
@@ -161,20 +287,24 @@ def filter_results(rpc, data, filter_or_none, debug=False):
     if filter_or_none is None:
         return data
 
-    if 'type' not in filter_or_none.attrib or filter_or_none.attrib['type'] == "subtree":
+    type_attr_name = qmap("nc") + "type"
+    select_attr_name = qmap("nc") + "select"
+
+    if type_attr_name not in filter_or_none.attrib or filter_or_none.attrib[
+            type_attr_name] == "subtree":
         # Check for the pathalogical case of empty filter since that's easy to implement.
         if not filter_or_none.getchildren():
-            return elm("data")
+            return elm("nc:data")
 
         xpf = filter_to_xpath(filter_or_none)
 
-    elif filter_or_none.attrib['type'] == "xpath":
-        if 'select' not in filter_or_none.attrib:
-            raise error.MissingAttributeProtoError(rpc, filter_or_none, "select")
-        xpf = filter_or_none.attrib['select']
+    elif filter_or_none.attrib[type_attr_name] == "xpath":
+        if select_attr_name not in filter_or_none.attrib:
+            raise error.MissingAttributeProtoError(rpc, filter_or_none, select_attr_name)
+        xpf = filter_or_none.attrib[select_attr_name]
     else:
-        msg = "unexpected type: " + str(filter_or_none.attrib['type'])
-        raise error.BadAttributeProtoError(rpc, filter_or_none, "type", message=msg)
+        msg = "unexpected type: " + str(filter_or_none.attrib[type_attr_name])
+        raise error.BadAttributeProtoError(rpc, filter_or_none, type_attr_name, message=msg)
 
     logger.debug("Filtering on xpath expression: %s", str(xpf))
     return xpath_filter_result(data, xpf)
@@ -409,40 +539,6 @@ def filter_list_iter(filter_list, key_xpath, keys):
                 #     yield key, filter_elm
                 # except ValueError:
                 #     pass
-
-
-def linearize(el, ns, path):
-
-    for child in el:
-        if len(child) > 0:
-            tag = etree.QName(child.tag).localname
-            text = f'{path}/{ns}:{tag}'
-            yield from linearize(child, ns, text)
-        else:
-            tag = etree.QName(child.tag).localname
-            text = f'/{ns}:{tag}'
-            if child.text is not None and child.text.strip() != '':
-                text = f'[{ns}:{tag}="{child.text.strip()}"]'
-            yield path + text
-
-
-def resolve_ns(nsmap):
-    ns = 'xmlns'
-    for name, uri in nsmap.items():
-        if name is not None:
-            ns = name
-    return ns
-
-
-def filter_to_xpath(filter_or_none):
-    root = filter_or_none[0]
-    root_tag = etree.QName(root.tag).localname
-    ns = resolve_ns(root.nsmap)
-    xpaths = []
-    for path in linearize(root, ns, f'/{ns}:{root_tag}'):
-        xpaths.append(path)
-
-    return ' | '.join(xpaths)
 
 
 __author__ = 'Christian Hopps'

--- a/pylintrc
+++ b/pylintrc
@@ -48,6 +48,7 @@ extension-pkg-whitelist=lxml
 # C0111 Invalid constant name (global variables)
 # C0325 Unnecessary parens after 'return' keyword
 # C0326 No space allowed before bracket
+# C0415 Import outside top level
 # R0201 Method could be a funcion
 # R0902 Too many instance attributes
 # R0903 Too few pubilc methods
@@ -59,7 +60,7 @@ extension-pkg-whitelist=lxml
 # W0232 Class has no __init__ method
 # W0511 XXX
 # W0703 Catching too general exception Exception
-disable=I,R,C0103,C0111,C0302,C0325,C0326,R0201,R0902,R0903,R0922,R0923,W0105,W0232,W0511,W0603,W0613,W0703
+disable=I,R,C0103,C0111,C0302,C0325,C0326,C0415,R0201,R0902,R0903,R0922,R0923,W0105,W0232,W0511,W0603,W0613,W0703
 
 [REPORTS]
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -20,7 +20,7 @@
 from __future__ import absolute_import, division, unicode_literals, print_function, nested_scopes
 import getpass
 import logging
-from netconf import NSMAP, qmap
+from netconf import NSMAP, qmap, nsmap_add
 import netconf.util as ncutil
 import netconf.error as ncerror
 import netconf.server as ncserver
@@ -31,6 +31,7 @@ NC_PORT = None
 NC_DEBUG = True
 
 mock_module = "urn:mock:module"
+nsmap_add('xmlns', 'http://tail-f.com/ns/ncs')
 
 
 class MockMethods(object):

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -30,8 +30,8 @@ nc_server = None
 NC_PORT = None
 NC_DEBUG = True
 
-mock_module = "urn:mock:module"
-nsmap_add('xmlns', 'http://tail-f.com/ns/ncs')
+mock_module = "urn:test:mock"
+nsmap_add('t', 'urn:test:mock')
 
 
 class MockMethods(object):
@@ -41,32 +41,38 @@ class MockMethods(object):
     The server return not-implemented if the method is not found in the methods object,
     so feel free to use duck-typing here (i.e., no need to inherit)
     """
-
     def nc_append_capabilities(self, capabilities):  # pylint: disable=W0613
         """The server should append any capabilities it supports to capabilities"""
         ncutil.subelm(capabilities, "capability").text = mock_module
         ncutil.subelm(capabilities,
                       "capability").text = "urn:ietf:params:netconf:capability:xpath:1.0"
+        ncutil.subelm(capabilities, "capability").text = "urn:test:mock"
 
     def rpc_get(self, session, rpc, filter_or_none):  # pylint: disable=W0613
-        data = ncutil.elm("data")
-        cont = ncutil.subelm(data, "interfaces")
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "Ethernet0/0"))
-        listval.append(ncutil.leaf_elm("shutdown", "true"))
-        listval.append(ncutil.leaf_elm("state", "down"))
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "Ethernet0/1"))
-        listval.append(ncutil.leaf_elm("shutdown", "false"))
-        listval.append(ncutil.leaf_elm("state", "down"))
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "FastEthernet1/0"))
-        listval.append(ncutil.leaf_elm("shutdown", "false"))
-        listval.append(ncutil.leaf_elm("state", "up"))
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "FastEthernet1/1"))
-        listval.append(ncutil.leaf_elm("shutdown", "false"))
-        listval.append(ncutil.leaf_elm("state", "down"))
+        data = ncutil.elm("nc:data")
+        cont = ncutil.subelm(data, "t:interfaces")
+        # Not in config
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "AutoInterface0/0"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
+        listval.append(ncutil.leaf_elm("t:state", "up"))
+        # In config
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "Ethernet0/0"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "true"))
+        listval.append(ncutil.leaf_elm("t:state", "down"))
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "Ethernet0/1"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
+        listval.append(ncutil.leaf_elm("t:state", "down"))
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "FastEthernet1/0"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
+        listval.append(ncutil.leaf_elm("t:state", "up"))
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "FastEthernet1/1"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
+        listval.append(ncutil.leaf_elm("t:state", "down"))
 
         return ncutil.filter_results(rpc, data, filter_or_none)
 
@@ -76,23 +82,23 @@ class MockMethods(object):
             # Really this should be a different error its a bad value for source not missing
             raise ncerror.MissingElementProtoError(rpc, ncutil.qname("nc:running"))
 
-        data = ncutil.elm("data")
-        cont = ncutil.subelm(data, "interfaces")
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "Ethernet0/0"))
-        listval.append(ncutil.leaf_elm("shutdown", "true"))
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "Ethernet0/1"))
-        listval.append(ncutil.leaf_elm("shutdown", "false"))
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "FastEthernet1/0"))
-        listval.append(ncutil.leaf_elm("shutdown", "false"))
-        listval = ncutil.subelm(cont, "interface")
-        listval.append(ncutil.leaf_elm("name", "FastEthernet1/1"))
-        listval.append(ncutil.leaf_elm("shutdown", "false"))
-        # Missing from operational
-        listval.append(ncutil.leaf_elm("name", "GigabitEthernet2/0"))
-        listval.append(ncutil.leaf_elm("shutdown", "false"))
+        data = ncutil.elm("nc:data")
+        cont = ncutil.subelm(data, "t:interfaces")
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "Ethernet0/0"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "true"))
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "Ethernet0/1"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "FastEthernet1/0"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
+        listval = ncutil.subelm(cont, "t:interface")
+        listval.append(ncutil.leaf_elm("t:name", "FastEthernet1/1"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
+        # Not in operational
+        listval.append(ncutil.leaf_elm("t:name", "GigabitEthernet2/0"))
+        listval.append(ncutil.leaf_elm("t:shutdown", "false"))
 
         return ncutil.filter_results(rpc, data, filter_or_none)
 
@@ -121,12 +127,11 @@ def init_mock_server():
         logger.error("XXX Called init_mock_server called multiple times")
     else:
         sctrl = ncserver.SSHUserPassController(username=getpass.getuser(), password="admin")
-        init_mock_server.server = ncserver.NetconfSSHServer(
-            server_ctl=sctrl,
-            server_methods=MockMethods(),
-            port=None,
-            host_key="tests/host_key",
-            debug=NC_DEBUG)
+        init_mock_server.server = ncserver.NetconfSSHServer(server_ctl=sctrl,
+                                                            server_methods=MockMethods(),
+                                                            port=None,
+                                                            host_key="tests/host_key",
+                                                            debug=NC_DEBUG)
     return init_mock_server.server.port
 
 

--- a/tests/test_netconf.py
+++ b/tests/test_netconf.py
@@ -32,22 +32,28 @@ def setup_module(unused_module):
     NC_PORT = init_mock_server()
 
 
-def test_query():
-    query = """
-    <get>
-    <filter type="subtree">
-    <devices xmlns="http://tail-f.com/ns/ncs">
-    <global-settings/>
-    </devices>
-    </filter>
-    </get>
-    """
-
+def test_xpath_query():
     query = """
     <get>
     <filter type="xpath" select="/devices/global-settings"/>
     </get>
     """
+    logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
+    session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
+    session.send_rpc(query)
+
+
+def test_subtree_query():
+    query = """
+        <get>
+        <filter type="subtree">
+        <devices xmlns="http://tail-f.com/ns/ncs">
+        <global-settings/>
+        </devices>
+        </filter>
+        </get>
+        """
+
     logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
     session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
     session.send_rpc(query)

--- a/tests/test_netconf.py
+++ b/tests/test_netconf.py
@@ -18,9 +18,12 @@
 #
 from __future__ import absolute_import, division, unicode_literals, print_function, nested_scopes
 import logging
+from lxml import etree
+
 import netconf.client as client
 from netconf.error import NetconfError
 from mockserver import init_mock_server
+from testutil import xml_eq
 
 logger = logging.getLogger(__name__)
 NC_PORT = None
@@ -32,52 +35,162 @@ def setup_module(unused_module):
     NC_PORT = init_mock_server()
 
 
-def test_xpath_query():
-    query = """
-    <get>
-    <filter type="xpath" select="/devices/global-settings"/>
-    </get>
-    """
+def test_xpath_query(caplog):
+    select = "/t:interfaces/t:interface[t:name='Ethernet0/0']/t:shutdown"
+
+    caplog.set_level(logging.DEBUG)
     logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
     session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
-    session.send_rpc(query)
+
+    cmptree = etree.fromstring("""
+        <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <interfaces xmlns="urn:test:mock">
+                <interface>
+                    <shutdown>true</shutdown>
+                </interface>
+            </interfaces>
+        </data>""")
+
+    results = session.get(select)
+    assert (xml_eq(results, cmptree))
 
 
-def test_subtree_query():
-    query = """
-        <get>
-        <filter type="subtree">
-        <devices xmlns="http://tail-f.com/ns/ncs">
-        <global-settings/>
-        </devices>
-        </filter>
-        </get>
+def test_xpath_config_query():
+    select = "/t:interfaces/t:interface[t:name='Ethernet0/1']"
+
+    logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
+    session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
+
+    cmptree = etree.fromstring("""
+        <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <interfaces xmlns="urn:test:mock">
+                <interface>
+                    <name>Ethernet0/1</name>
+                    <shutdown>false</shutdown>
+                </interface>
+            </interfaces>
+        </data>""")
+
+    results = session.get_config("running", select)
+    assert (xml_eq(results, cmptree))
+
+
+def test_xpath_query_multi():
+    select = ("/t:interfaces/t:interface[t:name='Ethernet0/0']/t:state | " +
+              "/t:interfaces/t:interface[t:name='Ethernet0/0']/t:shutdown")
+
+    logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
+    session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
+
+    cmptree = etree.fromstring("""
+        <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <interfaces xmlns="urn:test:mock">
+                <interface>
+                    <shutdown>true</shutdown>
+                    <state>down</state>
+                </interface>
+            </interfaces>
+        </data>""")
+
+    results = session.get(select)
+    assert (xml_eq(results, cmptree))
+
+
+def test_subtree_any_ns_query():
+    select = """
+        <interfaces>
+        <interface>
+        <name>Ethernet0/0</name>
+        <state/>
+        </interface>
+        </interfaces>
         """
 
     logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
     session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
-    session.send_rpc(query)
+
+    cmptree = etree.fromstring("""
+        <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <interfaces xmlns="urn:test:mock">
+                <interface>
+                    <name>Ethernet0/0</name>
+                    <state>down</state>
+                </interface>
+            </interfaces>
+        </data>""")
+
+    results = session.get(select)
+    assert (xml_eq(results, cmptree))
+
+
+def test_subtree_explicit_ns_query():
+    select = """
+        <foo:interfaces xmlns:foo="urn:test:mock">
+        <foo:interface>
+        <foo:name>Ethernet0/0</foo:name>
+        <foo:state/>
+        </foo:interface>
+        </foo:interfaces>
+        """
+
+    logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
+    session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
+
+    cmptree = etree.fromstring("""
+        <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <interfaces xmlns="urn:test:mock">
+                <interface>
+                    <name>Ethernet0/0</name>
+                    <state>down</state>
+                </interface>
+            </interfaces>
+        </data>""")
+
+    results = session.get(select)
+    assert (xml_eq(results, cmptree))
+
+
+def test_subtree_explicit_ns_query_elm():
+    select = etree.fromstring("""
+        <foo:interfaces xmlns:foo="urn:test:mock">
+        <foo:interface>
+        <foo:name>Ethernet0/0</foo:name>
+        <foo:state/>
+        </foo:interface>
+        </foo:interfaces>
+        """)
+
+    logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
+    session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
+
+    cmptree = etree.fromstring("""
+        <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <interfaces xmlns="urn:test:mock">
+                <interface>
+                    <name>Ethernet0/0</name>
+                    <state>down</state>
+                </interface>
+            </interfaces>
+        </data>""")
+
+    results = session.get(select)
+    assert (xml_eq(results, cmptree))
 
 
 def test_bad_query():
     session = client.NetconfSSHSession("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG)
     try:
-        unused, unused, output = session.send_rpc("<get><unknown/></get>")
+        _, _, output = session.send_rpc("<get><unknown/></get>")
         logger.warning("Got unexpected output: %s", str(output))
     except NetconfError:
         pass
 
 
 def test_context_manager():
-    select = """
-    <devices xmlns="http://tail-f.com/ns/ncs">
-    <global-settings/>
-    </devices>
-    """
-    select = "/devices/global-settings"
     logger.info("Connecting to 127.0.0.1 port %d", NC_PORT)
     with client.connect_ssh("127.0.0.1", password="admin", port=NC_PORT, debug=NC_DEBUG) as session:
-        session.get(select)
+        _ = session.get()
+        # print(etree.tostring(results))
 
 
 __author__ = 'Christian Hopps'

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 eval: (yapf-mode 1) -*-
+#
+# February 11 2020, Christian E. Hopps <chopps@gmail.com>
+#
+# Copyright (c) 2020 by Christian E. Hopps.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import, division, unicode_literals, print_function, nested_scopes
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def xml_eq(a, b):
+    if len(a) != len(b):
+        logger.error("len(a) (%d) != len(b) (%d)", len(a), len(b))
+        return False
+
+    if a.tag != b.tag:
+        logger.error("a.tag (%s) != b.tag (%s)", str(a.tag), str(b.tag))
+        return False
+
+    if a is not None and len(a):
+        for ae, be in zip(a, b):
+            if not xml_eq(ae, be):
+                return False
+
+    if a.text is None and b.text is not None:
+        logger.error("a.text (None) != b.text (%s)", str(b.text))
+        return False
+    elif a.text is not None and b.text is None:
+        logger.error("a.text (%s) != b.text (None)", str(a.text))
+        return False
+    elif a.text:
+        atext = a.text.strip()
+        btext = b.text.strip()
+        if atext == btext:
+            return True
+        logger.error("a.text (%s) != b.text (%s)", atext, btext)
+        return False
+    return True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py36
 platform = linux2|darwin
 
 [testenv]


### PR DESCRIPTION
Add subtree filter support and cleans up default namespace use (removes) [started from code in #34 from @psikala]

Sub-tree filter support is added by converting the sub-tree filter to an xpath expression.

Additionally netconf is no longer set as the default namespace. This is technically a non-backward compatible change as some users may have assumed a non-prefixed element would be inside the namespace. This code should be updated to use a "nc:" prefix instead.